### PR TITLE
implements round robin over all the network nodes when node forwarding

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,7 +64,7 @@ func runServiceRun(cmd *cobra.Command, args []string) error {
 
 	var cproxy *consoleProxy
 	if runArgs.consoleProxy {
-		cproxy = newConsoleProxy(log, cfg.Console.LocalPort, cfg.Console.URL, cfg.Node.Host, Version)
+		cproxy = newConsoleProxy(log, cfg.Console.LocalPort, cfg.Console.URL, cfg.Nodes.Hosts[0], Version)
 		go func() {
 			defer cancel()
 			err := cproxy.Start()

--- a/wallet/config.go
+++ b/wallet/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	TokenExpiry encoding.Duration
 	Port        int
 	Host        string
-	Node        NodeConfig
+	Nodes       NodesConfig
 	RsaKey      string
 	Console     ConsoleConfig
 }
@@ -45,9 +45,8 @@ type ConsoleConfig struct {
 	LocalPort int
 }
 
-type NodeConfig struct {
-	Port    int
-	Host    string
+type NodesConfig struct {
+	Hosts   []string
 	Retries uint64
 }
 
@@ -57,9 +56,17 @@ func NewDefaultConfig() Config {
 	return Config{
 		Level:       encoding.LogLevel{Level: zap.InfoLevel},
 		TokenExpiry: encoding.Duration{Duration: tokenExpiry},
-		Node: NodeConfig{
-			Host:    "n08.testnet.vega.xyz",
-			Port:    3002,
+		Nodes: NodesConfig{
+			Hosts: []string{
+				"n01.testnet.vega.xyz:3002",
+				"n02.testnet.vega.xyz:3002",
+				"n03.testnet.vega.xyz:3002",
+				"n04.testnet.vega.xyz:3002",
+				"n05.testnet.vega.xyz:3002",
+				"n06.testnet.vega.xyz:3002",
+				"n07.testnet.vega.xyz:3002",
+				"n09.testnet.vega.xyz:3002",
+			},
 			Retries: 5,
 		},
 		Host:   "localhost",

--- a/wallet/node_forward.go
+++ b/wallet/node_forward.go
@@ -2,7 +2,8 @@ package wallet
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"sync/atomic"
 
 	"code.vegaprotocol.io/go-wallet/proto/api"
 
@@ -12,31 +13,47 @@ import (
 )
 
 type nodeForward struct {
-	log     *zap.Logger
-	nodeCfg NodeConfig
-	clt     api.TradingClient
-	conn    *grpc.ClientConn
+	log      *zap.Logger
+	nodeCfgs NodesConfig
+	clts     []api.TradingClient
+	conns    []*grpc.ClientConn
+	next     uint64
 }
 
-func NewNodeForward(log *zap.Logger, nodeConfig NodeConfig) (*nodeForward, error) {
-	nodeAddr := fmt.Sprintf("%v:%v", nodeConfig.Host, nodeConfig.Port)
-	conn, err := grpc.Dial(nodeAddr, grpc.WithInsecure())
-	if err != nil {
-		return nil, err
+func NewNodeForward(log *zap.Logger, nodeConfigs NodesConfig) (*nodeForward, error) {
+	if len(nodeConfigs.Hosts) <= 0 {
+		return nil, errors.New("no node specified for node forwarding")
 	}
 
-	client := api.NewTradingClient(conn)
+	var (
+		clts  []api.TradingClient
+		conns []*grpc.ClientConn
+	)
+	for _, v := range nodeConfigs.Hosts {
+		conn, err := grpc.Dial(v, grpc.WithInsecure())
+		if err != nil {
+			return nil, err
+		}
+		conns = append(conns, conn)
+		clts = append(clts, api.NewTradingClient(conn))
+	}
+
 	return &nodeForward{
-		log:     log,
-		nodeCfg: nodeConfig,
-		clt:     client,
-		conn:    conn,
+		log:      log,
+		nodeCfgs: nodeConfigs,
+		clts:     clts,
+		conns:    conns,
 	}, nil
 }
 
 func (n *nodeForward) Stop() error {
-	n.log.Info("closing grpc client", zap.String("address", fmt.Sprintf("%v:%v", n.nodeCfg.Host, n.nodeCfg.Port)))
-	return n.conn.Close()
+	for i, v := range n.nodeCfgs.Hosts {
+		n.log.Info("closing grpc client", zap.String("address", v))
+		if err := n.conns[i].Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (n *nodeForward) Send(ctx context.Context, tx *SignedBundle, ty api.SubmitTransactionRequest_Type) error {
@@ -46,13 +63,21 @@ func (n *nodeForward) Send(ctx context.Context, tx *SignedBundle, ty api.SubmitT
 	}
 	return backoff.Retry(
 		func() error {
-			resp, err := n.clt.SubmitTransaction(ctx, &req)
+			clt := n.nextClt()
+			resp, err := clt.SubmitTransaction(ctx, &req)
 			if err != nil {
 				return err
 			}
 			n.log.Debug("response from SubmitTransaction", zap.Bool("success", resp.Success))
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), n.nodeCfg.Retries),
+		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), n.nodeCfgs.Retries),
 	)
+}
+
+func (r *nodeForward) nextClt() api.TradingClient {
+	n := atomic.AddUint64(&r.next, 1)
+	r.log.Info("sending transaction to vega node",
+		zap.String("host", r.nodeCfgs.Hosts[(int(n)-1)%len(r.clts)]))
+	return r.clts[(int(n)-1)%len(r.clts)]
 }

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -141,7 +141,7 @@ func NewService(log *zap.Logger, cfg *Config, rootPath string) (*Service, error)
 	if err != nil {
 		return nil, err
 	}
-	nodeForward, err := NewNodeForward(log, cfg.Node)
+	nodeForward, err := NewNodeForward(log, cfg.Nodes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Update the node configuration to take a list of nodes instead of a single one.
Node forwarding is then do with a simple round robing over the different nodes.