### PR TITLE
add user friendly at startup of the wallet

### DIFF
--- a/cmd/console.go
+++ b/cmd/console.go
@@ -47,10 +47,10 @@ func (c *consoleProxy) Start() error {
 		Handler: &proxy,
 	}
 
-	c.log.Info("starting console proxy",
-		zap.String("proxy.address", consoleProxyAddr),
-		zap.String("address", c.consoleURL),
-	)
+	// c.log.Info("starting console proxy",
+	// 	zap.String("proxy.address", consoleProxyAddr),
+	// 	zap.String("address", c.consoleURL),
+	// )
 	return c.s.ListenAndServe()
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,6 +83,12 @@ func runServiceRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	printStartupMessage(
+		cfg.Console.URL,
+		fmt.Sprintf("localhost:%v", cfg.Console.LocalPort),
+		fmt.Sprintf("%v:%v", cfg.Host, cfg.Port),
+	)
+
 	waitSig(ctx, cancel, log)
 
 	err = srv.Stop()

--- a/cmd/run_dump_startup.go
+++ b/cmd/run_dump_startup.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"os"
+	"text/template"
+)
+
+const startupT = `Wallet http service started at: http://{{.WalletServiceLocalAddress}}
+Wallet console proxy started at: http://{{.ConsoleProxyLocalAddress}} proxying {{.ConsoleProxyProxiedAddress}}
+
+Available endpoints:
+ - status:          GET    http://{{.WalletServiceLocalAddress}}/api/v1/status
+ - login:           POST   http://{{.WalletServiceLocalAddress}}/api/v1/auth/token
+ - logout:          DELETE http://{{.WalletServiceLocalAddress}}/api/v1/auth/token
+ - create wallet:   POST   http://{{.WalletServiceLocalAddress}}/api/v1/wallets
+ - create key:      POST   http://{{.WalletServiceLocalAddress}}/api/v1/keys
+ - list keys:       GET    http://{{.WalletServiceLocalAddress}}/api/v1/keys
+ - get key:         GET    http://{{.WalletServiceLocalAddress}}/api/v1/keys:keyid
+ - taint key:       PUT    http://{{.WalletServiceLocalAddress}}/api/v1/keys:keyid/taint
+ - update meta:     PUT    http://{{.WalletServiceLocalAddress}}/api/v1/keys:keyid/metadata
+ - sign:            POST   http://{{.WalletServiceLocalAddress}}/api/v1/messages/sign
+ - sign sync:       POST   http://{{.WalletServiceLocalAddress}}/api/v1/messages/sign/sync
+ - sign commit:     POST   http://{{.WalletServiceLocalAddress}}/api/v1/messages/sign/commit
+ - download wallet: GET    http://{{.WalletServiceLocalAddress}}/api/v1/wallets
+`
+
+func printStartupMessage(consoleURL, consoleLocalHost, serviceHost string) {
+	params := struct {
+		ConsoleProxyLocalAddress,
+		ConsoleProxyProxiedAddress,
+		WalletServiceLocalAddress string
+	}{
+		ConsoleProxyLocalAddress:   consoleLocalHost,
+		ConsoleProxyProxiedAddress: consoleURL,
+		WalletServiceLocalAddress:  serviceHost,
+	}
+
+	tmpl, err := template.New("wallet-cmdline").Parse(startupT)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(os.Stdout, params)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -155,7 +155,7 @@ func (s *Service) Start() error {
 		Handler: cors.AllowAll().Handler(s), // middlewar with cors
 	}
 
-	s.log.Info("starting wallet http server", zap.String("address", s.s.Addr))
+	// s.log.Info("starting wallet http server", zap.String("address", s.s.Addr))
 	return s.s.ListenAndServe()
 }
 


### PR DESCRIPTION
This add a nicer error message when the wallet is being started:
```
➜  go-wallet git:(feature/48-update-wallet-startup) ✗ go-wallet service run -p
Wallet http service started at: http://localhost:1789
Wallet console proxy started at: http://localhost:1847 proxying dev.vega.trading

Available endpoints:
 - status:          GET    http://localhost:1789/api/v1/status
 - login:           POST   http://localhost:1789/api/v1/auth/token
 - logout:          DELETE http://localhost:1789/api/v1/auth/token
 - create wallet:   POST   http://localhost:1789/api/v1/wallets
 - create key:      POST   http://localhost:1789/api/v1/keys
 - list keys:       GET    http://localhost:1789/api/v1/keys
 - get key:         GET    http://localhost:1789/api/v1/keys:keyid
 - taint key:       PUT    http://localhost:1789/api/v1/keys:keyid/taint
 - update meta:     PUT    http://localhost:1789/api/v1/keys:keyid/metadata
 - sign:            POST   http://localhost:1789/api/v1/messages/sign
 - sign sync:       POST   http://localhost:1789/api/v1/messages/sign/sync
 - sign commit:     POST   http://localhost:1789/api/v1/messages/sign/commit
 - download wallet: GET    http://localhost:1789/api/v1/wallets
```

close #48 