### PR TITLE
use syscall.Stdin for for read password

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func promptForPassphrase(msg ...string) (string, error) {
 	} else {
 		fmt.Print(msg[0])
 	}
-	password, err := terminal.ReadPassword(0)
+	password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Use syscall.Stdin for terminal read password instead of 0 (which is not stdin on windows...)

close #57