### PR TITLE
Feature/add default meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ The genkey command in that instruction will generate public and private keys for
 
 You’ll see an output with your public and private key. DO NOT SHARE YOUR PRIVATE KEY. You don’t need to save this information anywhere, as you’ll be able to retrieve it from your Wallet in the future.
 
+> Tip: You can give each new key a nickname/alias. 
+> When creating a key, run 
+> 
+> MacOS & Linux: `./vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="primary:true;name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`. 
+> 
+> Windows: `vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="primary:true;name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`
+
+> Tip: To give an existing key a nickname/alias, run 
+> 
+> MacOS & Linux: `./vegawallet meta --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY" --name="YOUR_CUSTOM_USERNAME" --pubkey="REPLACE_THIS_WITH_YOUR_PUBLIC_KEY"`. 
+> 
+> Windows: `vegawallet meta --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY" --name="YOUR_CUSTOM_USERNAME" --pubkey="REPLACE_THIS_WITH_YOUR_PUBLIC_KEY"`
+
 > Tip: You can see a list of available commands by running  ```./vegawallet -h``` on MacOS and Linux, or ```vegawallet -h``` on Windows.
 
 ## Run the Wallet service

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ vegawallet
 ```
 to execute the program.
 
+> Tip: You can see a list of available commands by running  `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows.
+
 ### Create name and passphrase
 Next, **create a user name and passphrase** for your Wallet, and **create a public and private key** (genkey). 
 
@@ -83,9 +85,9 @@ You’ll see an output with your public and private key. DO NOT SHARE YOUR PRIVA
 > Tip: You can give each new key a nickname/alias. 
 > When creating a key, run 
 > 
-> MacOS & Linux: `./vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="primary:true;name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`. 
+> MacOS & Linux: `./vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`. 
 > 
-> Windows: `vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="primary:true;name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`
+> Windows: `vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`
 
 > Tip: To give an existing key a nickname/alias, run 
 > 
@@ -93,7 +95,7 @@ You’ll see an output with your public and private key. DO NOT SHARE YOUR PRIVA
 > 
 > Windows: `vegawallet meta --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY" --name="YOUR_CUSTOM_USERNAME" --pubkey="REPLACE_THIS_WITH_YOUR_PUBLIC_KEY"`
 
-> Tip: You can see a list of available commands by running  ```./vegawallet -h``` on MacOS and Linux, or ```vegawallet -h``` on Windows.
+> Tip: You can also use the meta command to tag a key with other data you might want, using a property name and a value. This will be useful for developing with Vega Wallet in the future.
 
 ## Run the Wallet service
 Now, **connect your Wallet to the Testnet nodes**. The `init` command (below) will initialise the configuration. A configuration file will be stored in your home folder, in a folder called `.vega`.


### PR DESCRIPTION
This PR adds two things:

A new `--metas` flag for the genkey commands, which can be used like this:
```console
$ vegawallet genkey --name="bob" --metas="primary:true;name:Bob's fav key"
```
Which will generate a new key for bob, and add the following metadatas:
- [1] primary = true
- [2] name = Bob's fav key

This also create a default metada for all new key with no metadatas specified at creating time.
The new metatada key is `name` and the value will follow the following pattern: `(WALLET_OWNER_NAME)'s key len(OWNER_KEYPAIRS)`, so if Bob is creating his fifth key, it'll be named: `bob's key 5`.


closes #10