### PR TITLE
Release develop to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ vegawallet
 ```
 to execute the program.
 
+> Tip: You can see a list of available commands by running  `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows.
+
 ### Create name and passphrase
 Next, **create a user name and passphrase** for your Wallet, and **create a public and private key** (genkey). 
 
@@ -80,7 +82,20 @@ The genkey command in that instruction will generate public and private keys for
 
 You’ll see an output with your public and private key. DO NOT SHARE YOUR PRIVATE KEY. You don’t need to save this information anywhere, as you’ll be able to retrieve it from your Wallet in the future.
 
-> Tip: You can see a list of available commands by running  ```./vegawallet -h``` on MacOS and Linux, or ```vegawallet -h``` on Windows.
+> Tip: You can give each new key a nickname/alias. 
+> When creating a key, run 
+> 
+> MacOS & Linux: `./vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`. 
+> 
+> Windows: `vegawallet genkey -name="YOUR_CUSTOM_USERNAME" --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY"`
+
+> Tip: To give an existing key a nickname/alias, run 
+> 
+> MacOS & Linux: `./vegawallet meta --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY" --name="YOUR_CUSTOM_USERNAME" --pubkey="REPLACE_THIS_WITH_YOUR_PUBLIC_KEY"`. 
+> 
+> Windows: `vegawallet meta --metas="name:CHOOSE_CUSTOM_ALIAS_FOR_KEY" --name="YOUR_CUSTOM_USERNAME" --pubkey="REPLACE_THIS_WITH_YOUR_PUBLIC_KEY"`
+
+> Tip: You can also use the meta command to tag a key with other data you might want, using a property name and a value. This will be useful for developing with Vega Wallet in the future.
 
 ## Run the Wallet service
 Now, **connect your Wallet to the Testnet nodes**. The `init` command (below) will initialise the configuration. A configuration file will be stored in your home folder, in a folder called `.vega`.


### PR DESCRIPTION
Release develop to master

* add a new flag to the genkey command in order to specify metadatas
* generate a default metadata for a new key when running genkey
* add readme tips for giving keys aliases
* add general metadata tip
