### PR TITLE
Rename api-clients to api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
-	github.com/vegaprotocol/api-clients v0.30.3-0.20210209095344-3a9425de980a
+	github.com/vegaprotocol/api v0.0.0-20210316103830-9dda2b5cf44b
 	github.com/zannen/toml v0.3.2
 	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
-github.com/vegaprotocol/api-clients v0.30.3-0.20210209095344-3a9425de980a h1:1v6lDA/kaTxGpBKKz2111y7pJA6qe/hpoRGtU8QqxZ8=
-github.com/vegaprotocol/api-clients v0.30.3-0.20210209095344-3a9425de980a/go.mod h1:FSy8HG+7TserVjTdvxUgmSEH9tEqwbVr0y30VyA+H1c=
+github.com/vegaprotocol/api v0.0.0-20210316103830-9dda2b5cf44b h1:Ju80+qnHT0Csh9oUFPye8vPC0B5bfK2EsvKON5Hhg3w=
+github.com/vegaprotocol/api v0.0.0-20210316103830-9dda2b5cf44b/go.mod h1:T130O/Ui1oMsVc21QtxbtOrYtgD4G7BLigVY2h/BaIM=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zannen/toml v0.3.2 h1:IYPp4GVtabUyQpzSU6xP1VDyKR3Ico3qhNP2VxCkl2Y=

--- a/wallet/handler.go
+++ b/wallet/handler.go
@@ -10,7 +10,7 @@ import (
 	"code.vegaprotocol.io/go-wallet/wallet/crypto"
 
 	"github.com/golang/protobuf/proto"
-	types "github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto"
+	types "github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
 	"go.uber.org/zap"
 )
 

--- a/wallet/mocks/node_forward_mock.go
+++ b/wallet/mocks/node_forward_mock.go
@@ -10,7 +10,7 @@ import (
 
 	wallet "code.vegaprotocol.io/go-wallet/wallet"
 	gomock "github.com/golang/mock/gomock"
-	api "github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto/api"
+	api "github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto/api"
 )
 
 // MockNodeForward is a mock of NodeForward interface

--- a/wallet/node_forward.go
+++ b/wallet/node_forward.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto/api"
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto/api"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -12,8 +12,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/cors"
-	vproto "github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto"
-	"github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto/api"
+	vproto "github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
+	"github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto/api"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
 )

--- a/wallet/signed_bundle.go
+++ b/wallet/signed_bundle.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	types "github.com/vegaprotocol/api-clients/go/generated/code.vegaprotocol.io/vega/proto"
+	types "github.com/vegaprotocol/api/go/generated/code.vegaprotocol.io/vega/proto"
 )
 
 // here we implement Marhsalling for the SignedBundle


### PR DESCRIPTION
This PR updates references to the api repo: old name `api-clients`, new name `api`.