### PR TITLE
Update pr_verify_linked_issue.yml

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -1,6 +1,4 @@
-
 ---
-
 
 # This workflow will inspect a pull request to ensure there is a linked issue or a
 # valid issue is mentioned in the body. If neither is present it fails the check and adds
@@ -14,6 +12,7 @@ name: VerifyIssue
 
 jobs:
   verify_linked_issue:
+    if: startsWith(github.head_ref, 'renovate/') != true
     runs-on: ubuntu-latest
     name: Ensure Pull Request has a linked issue.
     steps:


### PR DESCRIPTION
updates the action to exclude running on the autogenerated renovate branch

closes #121 