### PR TITLE
Feature/config endpoint

### DIFF
--- a/cmd/service_run_startup.go
+++ b/cmd/service_run_startup.go
@@ -6,6 +6,7 @@ import (
 )
 
 const startupT = ` - get service status:      GET    {{.WalletServiceLocalAddress}}/api/v1/status
+ - config:                  GET    {{.WalletServiceLocalAddress}}/api/v1/config
  - login:                   POST   {{.WalletServiceLocalAddress}}/api/v1/auth/token
  - logout:                  DELETE {{.WalletServiceLocalAddress}}/api/v1/auth/token
  - create a wallet:         POST   {{.WalletServiceLocalAddress}}/api/v1/wallets

--- a/service/service.go
+++ b/service/service.go
@@ -28,7 +28,8 @@ import (
 
 type Service struct {
 	*httprouter.Router
-
+	
+	cfg         *Config
 	log         *zap.Logger
 	server      *http.Server
 	handler     WalletHandler
@@ -37,7 +38,6 @@ type Service struct {
 
 	version     string
 	versionHash string
-	cfg Config
 }
 
 // CreateWalletRequest describes the request for CreateWallet.
@@ -409,7 +409,7 @@ func NewService(log *zap.Logger, cfg *Config, h WalletHandler, a Auth, n NodeFor
 		handler:     h,
 		auth:        a,
 		nodeForward: n,
-		cfg: *cfg,
+		cfg: cfg,
 	}
 
 	s.server = &http.Server{
@@ -771,7 +771,7 @@ func (s *Service) Version(w http.ResponseWriter, _ *http.Request, _ httprouter.P
 
 func (s *Service) config(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	res := ConfigResponse{
-		Config: s.cfg,
+		Config: *s.cfg,
 	}
 	writeSuccess(w, res, http.StatusOK)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -409,7 +409,7 @@ func NewService(log *zap.Logger, cfg *Config, h WalletHandler, a Auth, n NodeFor
 		handler:     h,
 		auth:        a,
 		nodeForward: n,
-		cfg: cfg,
+		cfg:         cfg,
 	}
 
 	s.server = &http.Server{

--- a/service/service.go
+++ b/service/service.go
@@ -37,6 +37,7 @@ type Service struct {
 
 	version     string
 	versionHash string
+	cfg Config
 }
 
 // CreateWalletRequest describes the request for CreateWallet.
@@ -362,6 +363,11 @@ type VersionResponse struct {
 	VersionHash string `json:"versionHash"`
 }
 
+// ConfigResponse describes the response to a request that returns app hosts info.
+type ConfigResponse struct {
+	Config Config `json:"config"`
+}
+
 // WalletHandler ...
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/wallet_handler_mock.go -package mocks code.vegaprotocol.io/go-wallet/service WalletHandler
 type WalletHandler interface {
@@ -403,6 +409,7 @@ func NewService(log *zap.Logger, cfg *Config, h WalletHandler, a Auth, n NodeFor
 		handler:     h,
 		auth:        a,
 		nodeForward: n,
+		cfg: *cfg,
 	}
 
 	s.server = &http.Server{
@@ -413,6 +420,7 @@ func NewService(log *zap.Logger, cfg *Config, h WalletHandler, a Auth, n NodeFor
 	s.POST("/api/v1/auth/token", s.Login)
 	s.DELETE("/api/v1/auth/token", ExtractToken(s.Revoke))
 	s.GET("/api/v1/status", s.health)
+	s.GET("/api/v1/config", s.config)
 	s.POST("/api/v1/wallets", s.CreateWallet)
 	s.POST("/api/v1/wallets/import", s.ImportWallet)
 	s.GET("/api/v1/keys", ExtractToken(s.ListPublicKeys))
@@ -758,6 +766,13 @@ func (s *Service) Version(w http.ResponseWriter, _ *http.Request, _ httprouter.P
 		VersionHash: version.VersionHash,
 	}
 
+	writeSuccess(w, res, http.StatusOK)
+}
+
+func (s *Service) config(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	res := ConfigResponse{
+		Config: s.cfg,
+	}
 	writeSuccess(w, res, http.StatusOK)
 }
 


### PR DESCRIPTION
On the front end having the front end configured to be pointing to a different environment compared to the one the wallet is pointing at is a common mistake. By exposing the config for our test environments we can validate if the user is using an incorrect configuration and show them an error message.

Once #238 lands we can also instruct them what command to run to change to the configured environment to the appropriate one (or which FE environment to change to).

**Disclaimer**: My go skills are -1/10. If there is too much wrong with this that and would be too much effort to correct please feel free to just close this. However I thought I'd have a punt before asking more work on you guys.